### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,6 @@
-close-q.png: close-q.dot
-	dot -T png < close-q.dot > ~/public_html/close-q.png
+.SUFFIXES: .png .dot
+
+all: close-q.png
+
+.dot.png:
+	dot -T png $< > $@


### PR DESCRIPTION
Make makefile work under both GNU and BSD make.
Will build the specified PNG image in the current directory from DOT
sources.